### PR TITLE
[17.0] Deprecated XML declaration with Odoo >= 17

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         # https://github.com/prettier/prettier/issues/12143
         exclude: "}$"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-case-conflict
       - id: check-docstring-first

--- a/camptocamp_migration_tools/static/description/index.html
+++ b/camptocamp_migration_tools/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>

--- a/camptocamp_tools/static/description/index.html
+++ b/camptocamp_tools/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>

--- a/camptocamp_website_tools/static/description/index.html
+++ b/camptocamp_website_tools/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>


### PR DESCRIPTION
Remove these warnings during installation:

> 2025-04-11 06:36:51,192 63 WARNING odoodb py.warnings: /odoo/src/odoo/addons/base/models/ir_module.py:185: DeprecationWarning: XML declarations in HTML module descriptions are deprecated since Odoo 17, camptocamp_migration_tools can just have a UTF8 description with not need for a declaration.

> 2025-04-11 06:36:54,035 63 WARNING odoodb py.warnings: /odoo/src/odoo/addons/base/models/ir_module.py:185: DeprecationWarning: XML declarations in HTML module descriptions are deprecated since Odoo 17, camptocamp_tools can just have a UTF8 description with not need for a declaration.

[EDIT]

Also upgrade to `action/cache@v4` without change
As explained here: https://github.com/actions/cache/discussions/1510
> The new changes to the [actions/cache](https://github.com/actions/cache) should be seamless and fully backward compatible. You are not expected to change anything in your workflows to use the new service beyond upgrading to the latest releases.